### PR TITLE
fix: remove redundant typo code. redundant return statement (S1023)

### DIFF
--- a/server/go/server.go
+++ b/server/go/server.go
@@ -105,7 +105,6 @@ func writeJSON(w http.ResponseWriter, v interface{}) {
 func writeJSONError(w http.ResponseWriter, v interface{}, code int) {
 	w.WriteHeader(code)
 	writeJSON(w, v)
-	return
 }
 
 func writeJSONErrorMessage(w http.ResponseWriter, message string, code int) {


### PR DESCRIPTION
Hi Team,

I ran into this warning info from your Go sample code when I tried to integrate `Stripe Payment Service` into our product. I think this should be a typo.

```go
func writeJSONError(w http.ResponseWriter, v interface{}, code int) {
	w.WriteHeader(code)
	writeJSON(w, v)
        // redundant return statement (S1023) go-staticcheck
	return
}
```

But anyway, your sample code & videos are really helpful to us. Thanks much for your dedication and effort!

Regards,
Andy
